### PR TITLE
Fix: hbmqtt don't support websockets >8.1 yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ I recommend using a python virtual environment, with at least python 3.6:
 $ cd <tellmqtt main directory>
 $ python3 -m virtualenv -p python3 venv
 $ . venv/bin/activate
-$ pip3 install $(cat requirements.txt)
+$ pip3 install -r requirements.txt
 $ python3 -m tellmqtt -d /dev/tellstickDuo -h mqtt-server
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+websockets==8.1
 hbmqtt
 logger
 pyserial_asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-websockets==8.1 # hbmqtt don't support websockets version 9.x (yet)
-hbmqtt
+aMQTT
 logger
 pyserial_asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# hbmqtt don't support websockets version 9.x (yet)
 websockets==8.1
 hbmqtt
 logger

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# hbmqtt don't support websockets version 9.x (yet)
-websockets==8.1
+websockets==8.1 # hbmqtt don't support websockets version 9.x (yet)
 hbmqtt
 logger
 pyserial_asyncio


### PR DESCRIPTION
hbmqtt dont support websockets >8.1 yet

```bash
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/6d66/Repos/tellmqtt/tellmqtt/__main__.py", line 5, in <module>
    from hbmqtt.client import MQTTClient
  File "/home/6d66/Repos/tellmqtt/venv/lib/python3.8/site-packages/hbmqtt/client.py", line 13, in <module>
    from hbmqtt.session import Session
  File "/home/6d66/Repos/tellmqtt/venv/lib/python3.8/site-packages/hbmqtt/session.py", line 8, in <module>
    from hbmqtt.mqtt.publish import PublishPacket
  File "/home/6d66/Repos/tellmqtt/venv/lib/python3.8/site-packages/hbmqtt/mqtt/__init__.py", line 5, in <module>
    from hbmqtt.mqtt.packet import (
  File "/home/6d66/Repos/tellmqtt/venv/lib/python3.8/site-packages/hbmqtt/mqtt/packet.py", line 8, in <module>
    from hbmqtt.adapters import ReaderAdapter, WriterAdapter
  File "/home/6d66/Repos/tellmqtt/venv/lib/python3.8/site-packages/hbmqtt/adapters.py", line 6, in <module>
    from websockets.protocol import WebSocketCommonProtocol
ModuleNotFoundError: No module named 'websockets.protocol'
```