### PR TITLE
Adding support for Waveman Codeswitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ The following topics are published:
 
 The termo-/hygrometers have dipswitches to set the channel 1-4 and house 1-15
 
+### Waveman
+#### Waveman Codeswitch
+
+The Waveman codeswitch model reads/writes to 
+`tellstick/(in/out)/waveman/codeswitch/<house>/<unit>/set`
+
+where
+
+`<house>` is a letter 'a' - 'p' (case insensitive)
+
+`<unit>` is 1 - 16
+
+The value of the topic on input can be either `on` or `off` (case insensitive).
+
 
 ## HomeAssistant examples
 Here are examples on how to use tellmqtt with HomeAssistant and its mqtt-support.

--- a/tellmqtt/protocols/waveman.py
+++ b/tellmqtt/protocols/waveman.py
@@ -1,0 +1,73 @@
+"""
+Protocol for waveman
+
+Tested models:
+ - Waveman Codeswitch, article no 17.356
+"""
+
+import json
+from tellmqtt.common import protocoldata as pd
+import logging
+
+logger = logging.getLogger(__name__)
+
+class waveman:
+    def name(self):
+        return 'waveman'
+
+    def encode(self, protoarg, command, payload):
+        if not protoarg:
+            logger.warning("Protocol should be specified")
+            return None
+
+        protocol, *options = protoarg
+        logger.debug('codeswitch: encode %r %r=%r', options, command, payload)
+
+        if protocol != 'codeswitch':
+            logger.warning('no waveman encoder for protocol %r', protocol)
+            return None
+
+        try:
+            house, unit = options
+            if ord(house) >= ord('A'):
+                house = ord(house.upper()) - ord('A')
+                unit = int(unit) - 1
+            else: # for arctech codeswitch compatibility
+                house = int(house)
+                unit = int(unit)
+        except ValueError:
+            logger.warning("Expected options (house, unit), where values are convertible to int")
+            return
+
+        if not ((0 <= house <= 0xF) and (0 <= unit <= 0xF)):
+            logger.warning("house and unit should be in range [0, 0xF]")
+            return
+
+        states = {'ON' : True, 'OFF': False, '0': False, '1': True}
+        try:
+            state = states[payload.upper()]
+        except (KeyError, TypeError) as err:
+            logger.warning("Payload should have one of the following values: %s. Error: %r", ", ".join(states.keys()), err)
+            return
+
+        def encode_nibble(t):
+            one, zero = b'$kk$', b'$k$k'
+            return b''.join(one if (t >> i & 1) else zero for i in range(4))
+
+        encoded_state = b'$k$k$kk$$kk$$kk$$k+' if state else b'$k$k$k$k$k$k$k$k$k+'
+        res = b''.join([b'S', encode_nibble(house), encode_nibble(unit), encoded_state])
+        logger.debug("Encoded %r", res)
+        return bytearray(res)
+
+    def decode(self, msg):
+        if msg["model"] == 'codeswitch':
+            data = int(msg['data'], 16)
+            if data == 0:
+                return None
+            house = (data & 0xf)
+            unit = (data >> 4) & 0xf
+            method = 'ON' if (data & 0x800) else 'OFF'
+            return pd((msg["model"], house, unit), {"set": method})
+        else:
+            logger.warning("Model is not supported yet: %r", msg["model"])
+            return None

--- a/tellmqtt/tellstickhandler.py
+++ b/tellmqtt/tellstickhandler.py
@@ -5,6 +5,7 @@ from tellmqtt.common import protocoldata as pd
 from tellmqtt.protocols.fineoffset import fineoffset
 from tellmqtt.protocols.arctech import arctech
 from tellmqtt.protocols.mandolyn import mandolyn
+from tellmqtt.protocols.waveman import waveman
 
 import json
 
@@ -14,6 +15,7 @@ PROTOCOLS = [
     arctech(),
     fineoffset(),
     mandolyn(),
+    waveman(),
 ]
 
 class TellstickHandler:
@@ -41,7 +43,7 @@ class TellstickHandler:
     def decode(self, b):
         if b.startswith(b'+W'):
             d = self.itemize(b[2:])
-        elif b.startswith(b'+T'):
+        elif b.startswith((b'+T', b'+S')):
             return None # ack on command
         else:
             logger.warning('unknown input {!r}'.format(b))


### PR DESCRIPTION
Based it on the existing implementation for the Arctech codeswitch. Only OFF command differs. Have not tested the decode-function, as I don't own a remote for my switch, but it should work exactly as for the Arctech variant.

One difference compared to the Arctech implementation is that I chose to support topics more in line with the actual marking on the rotary switches on the unit. House is letter A to P, and unit starts with 1. Using numbers from 0 to 15 for both will still work, but is not documented in README. 